### PR TITLE
Make Groestl only, Fix openCL, Edit help message, Fix Windows Makefile

### DIFF
--- a/Makefile.Win32
+++ b/Makefile.Win32
@@ -1,9 +1,9 @@
 CC = cl
-OPENSSL_DIR = C:\OpenSSL-Win32
-PTHREADS_DIR = C:\pthreads-w32-2-8-0-release
-PCRE_DIR = C:\pcre-7.9-src
+OPENSSL_DIR = C:\Users\User\Downloads\vanitygen-groestl
+PTHREADS_DIR = C:\Users\User\Downloads\pthreads.2
+PCRE_DIR = C:\Users\User\Downloads\pcre-7.9-dll\pcre-7.9-dll
 CURL_DIR = C:\curl-7.26.0-x86\builds\libcurl-release-static-ssl-static-ipv6-sspi
-OPENCL_DIR = "C:\Program Files (x86)\AMD APP"
+OPENCL_DIR = "C:\Program Files (x86)\AMD APP SDK\2.9"
 OPENCL_INCLUDE = /I$(OPENCL_DIR)\include
 OPENCL_LIBS = $(OPENCL_DIR)\lib\x86\OpenCL.lib
 CURL_INCLUDE = /I$(CURL_DIR)\include /DCURL_STATICLIB
@@ -11,20 +11,20 @@ CURL_LIBS = $(CURL_DIR)\lib\libcurl_a.lib
 CFLAGS_BASE = /D_WIN32 /DPTW32_STATIC_LIB /DPCRE_STATIC /I$(OPENSSL_DIR)\inc32 /I$(PTHREADS_DIR) /I$(PCRE_DIR) /Ox /Zi
 CFLAGS = $(CFLAGS_BASE) /GL
 LIBS = $(OPENSSL_DIR)\out32\libeay32.lib $(PTHREADS_DIR)\pthreadVC2.lib $(PCRE_DIR)\pcre.lib ws2_32.lib user32.lib advapi32.lib gdi32.lib /LTCG /DEBUG
-OBJS = vanitygen.obj oclvanitygen.obj oclengine.obj oclvanityminer.obj keyconv.obj pattern.obj util.obj winglue.obj
+OBJS = vanitygen.obj oclvanitygen.obj oclengine.obj oclvanityminer.obj keyconv.obj pattern.obj util.obj winglue.obj groestl.obj
 
 all: vanitygen.exe keyconv.exe
 
-vanitygen.exe: vanitygen.obj pattern.obj util.obj winglue.obj
+vanitygen.exe: vanitygen.obj pattern.obj util.obj winglue.obj groestl.obj
 	link /nologo /out:$@ $** $(LIBS)
 
-oclvanitygen.exe: oclvanitygen.obj oclengine.obj pattern.obj util.obj winglue.obj
+oclvanitygen.exe: oclvanitygen.obj oclengine.obj pattern.obj util.obj winglue.obj groestl.obj
 	link /nologo /out:$@ $** $(LIBS) $(OPENCL_LIBS)
 
-oclvanityminer.exe: oclvanityminer.obj oclengine.obj pattern.obj util.obj winglue.obj
+oclvanityminer.exe: oclvanityminer.obj oclengine.obj pattern.obj util.obj winglue.obj groestl.obj
 	link /nologo /out:$@ $** $(LIBS) $(OPENCL_LIBS) $(CURL_LIBS)
 
-keyconv.exe: keyconv.obj util.obj winglue.obj
+keyconv.exe: keyconv.obj util.obj winglue.obj groestl.obj
 	link /nologo /out:$@ $** $(LIBS)
 
 .c.obj:

--- a/calc_addrs.cl
+++ b/calc_addrs.cl
@@ -170,7 +170,7 @@ typedef struct {
 } bignum;
 
 __constant bn_word modulus[] = { MODULUS_BYTES };
-__constant bignum bn_zero;
+__constant bignum bn_zero = {};
 
 __constant bn_word mont_rr[BN_NWORDS] = { 0xe90a1, 0x7a2, 0x1, 0, };
 __constant bn_word mont_n0[2] = { 0xd2253531, 0xd838091d };

--- a/oclvanitygen.c
+++ b/oclvanitygen.c
@@ -29,7 +29,7 @@
 #include "pattern.h"
 #include "util.h"
 
-int GRSFlag = 0;
+int GRSFlag = 1;
 
 const char *version = VANITYGEN_VERSION;
 const int debug = 0;
@@ -40,7 +40,7 @@ usage(const char *name)
 {
 	fprintf(stderr,
 "oclVanitygen %s (" OPENSSL_VERSION_TEXT ")\n"
-"Usage: %s [-vqrik1GTS] [-d <device>] [-f <filename>|-] [<pattern>...]\n"
+"Usage: %s [-vqrik1TS] [-d <device>] [-f <filename>|-] [<pattern>...]\n"
 "Generates a groestlcoin receiving address matching <pattern>, and outputs the\n"
 "address and associated private key.  The private key may be stored in a safe\n"
 "location or imported into a groestlcoin client to spend any balance received on\n"
@@ -58,7 +58,6 @@ usage(const char *name)
 "-i            Case-insensitive prefix search\n"
 "-k            Keep pattern and continue search after finding a match\n"
 "-1            Stop after first match\n"
-"-G	       Generate Groestlcoin address\n"
 "-T            Generate groestlcoin testnet address\n"
 "-X <version>  Generate address with the given version\n"
 "-e            Encrypt private keys, prompt for password\n"
@@ -87,7 +86,7 @@ version, name);
 int
 main(int argc, char **argv)
 {
-	int addrtype = 0;
+	int addrtype = 36;
 	int privtype = 128;
 	int regex = 0;
 	int caseinsensitive = 0;

--- a/oclvanitygen.c
+++ b/oclvanitygen.c
@@ -60,8 +60,6 @@ usage(const char *name)
 "-1            Stop after first match\n"
 "-T            Generate groestlcoin testnet address\n"
 "-X <version>  Generate address with the given version\n"
-"-e            Encrypt private keys, prompt for password\n"
-"-E <password> Encrypt private keys with <password> (UNSAFE)\n"
 "-p <platform> Select OpenCL platform\n"
 "-d <device>   Select OpenCL device\n"
 "-D <devstr>   Use OpenCL device, identified by device string\n"

--- a/pattern.h
+++ b/pattern.h
@@ -35,7 +35,7 @@
 #include <unistd.h>
 #endif
 
-#define VANITYGEN_VERSION "0.22"
+#define VANITYGEN_VERSION "GROESTL"
 
 typedef struct _vg_context_s vg_context_t;
 

--- a/vanitygen.c
+++ b/vanitygen.c
@@ -32,7 +32,7 @@
 #include "pattern.h"
 #include "util.h"
 
-int GRSFlag = 0;
+int GRSFlag = 1;
 
 const char *version = VANITYGEN_VERSION;
 
@@ -297,7 +297,7 @@ usage(const char *name)
 {
 	fprintf(stderr,
 "Vanitygen %s (" OPENSSL_VERSION_TEXT ")\n"
-"Usage: %s [-vqnrik1GT] [-t <threads>] [-f <filename>|-] [<pattern>...]\n"
+"Usage: %s [-vqnrik1T] [-t <threads>] [-f <filename>|-] [<pattern>...]\n"
 "Generates a groestlcoin receiving address matching <pattern>, and outputs the\n"
 "address and associated private key.  The private key may be stored in a safe\n"
 "location or imported into a groestlcoin client to spend any balance received on\n"
@@ -313,7 +313,6 @@ usage(const char *name)
 "-i            Case-insensitive prefix search\n"
 "-k            Keep pattern and continue search after finding a match\n"
 "-1            Stop after first match\n"
-"-G	       Generate Groestlcoin address\n"
 "-T            Generate Groestlcoin testnet address\n"
 "-X <version>  Generate address with the given version\n"
 "-F <format>   Generate address with the given format (pubkey or script)\n"
@@ -333,7 +332,7 @@ version, name);
 int
 main(int argc, char **argv)
 {
-	int addrtype = 0;
+	int addrtype = 36;
 	int scriptaddrtype = 5;
 	int privtype = 128;
 	int pubkeytype;

--- a/vanitygen.c
+++ b/vanitygen.c
@@ -317,8 +317,6 @@ usage(const char *name)
 "-X <version>  Generate address with the given version\n"
 "-F <format>   Generate address with the given format (pubkey or script)\n"
 "-P <pubkey>   Specify base public key for piecewise key generation\n"
-"-e            Encrypt private keys, prompt for password\n"
-"-E <password> Encrypt private keys with <password> (UNSAFE)\n"
 "-t <threads>  Set number of worker threads (Default: number of CPUs)\n"
 "-f <file>     File containing list of patterns, one per line\n"
 "              (Use \"-\" as the file name for stdin)\n"


### PR DESCRIPTION
I also suggest manually modifying the Readme and perhaps the changelog if you have one and also including a Linux binary.  I updated post to include links to Windows and Linux binaries I just compiled release version "GROESTL".  Be sure to include the new calc_addrs.cl with your binaries as it has a fix for many openCL devices mostly important to Windows(I already included it in zip files for binaries and calc_addrs.cl change works for both Windows and Linux).  If/when you publish a new release don't remove the old release in case there is a bug somewhere I missed.  I ran through my tests fairly quickly to get this PR out but couldn't think of anything else to try testing.  It should be good to go.  PrivKeys imported to ArmoryQT just fine generated from vanitygen and oclvanitygen on both Linux and Windows.

Link to binaries(Link only lasts 30 days): https://ufile.io/ec9191
May be a good idea to extract zip and upload the different archives individually.  Up to you if you want to include the external dll win32 version.  I personally wouldn't if I were you, the other win32 zip has the dll files embedded into the exe so you don't need them externally.  The only benefit to Win32 external dll version is it will run in Linux under Wine.  But... theres also a Linux binary and Wine + OpenCL = no good.

> A standalone command line vanity address generator called vanitygen.
> 
> Vanitygen is written in C, and is provided in source code form and 
> pre-built Win32 and Linux binaries.  At present, vanitygen can be built on Linux, 
> and requires the openssl and pcre libraries.
> 
> Vanitygen can generate regular groestlcoin addresses and testnet addresses.
> 
> Vanitygen can search for exact prefixes or regular expression matches.  
> When searching for exact prefixes, vanitygen will ensure that the 
> prefix is possible, will provide a difficulty estimate, and will run 
> about 30% faster.  Exact prefixes are case-sensitive by default, but 
> may be searched case-insensitively using the "-i" option.  Regular 
> expression patterns follow the Perl-compatible regular expression 
> language.
> 
> Vanitygen can accept a list of patterns to search for, either on the 
> command line, or from a file or stdin using the "-f" option.  File 
> sources should have one pattern per line.  When searching for N exact 
> prefixes, performance of O(logN) can be expected, and extremely long 
> lists of prefixes will have little effect on search rate.  Searching 
> for N regular expressions will have varied performance depending on the 
> complexity of the expressions, but O(N) performance can be expected.
> 
> By default, vanitygen will spawn one worker thread for each CPU in your 
> system.  If you wish to limit the number of worker threads created by 
> vanitygen, use the "-t" option.
> 
> Example:
> 
> Generate using CPU:
> Linux: ./vanitygen Fgrs
> Windows: vanitygen.exe Fgrs
> Difficulty: 78508
> Pattern: Fgrs                                                                  
> Address: Fgrsa16NshK1ua6KyBSXahz6D9PYUbvL3d
> Privkey: 5JssG8to6x62vf9pC7ktJhXc3jJV31JR1Do7qLvQEx8wVUQ37op
> 
> Generate using GPU:
> Linux: ./oclvanitygen Fgrs
> Windows: oclvanitygen.exe Fgrs
> Difficulty: 78508
> Pattern: Fgrs                                                                  
> Address: FgrsjEdkYaubKoxqKJ9uGP9pHxknhrn7Vj
> Privkey: 5KHCnR5HAkdrePoQiXcvJh3ZADt1EymnryySi4tkqTArnQGTwQc


OH AND ONE GREAT TIP FOR LINUX:
> 
> -------
> Fix libcrypto.so.1.0.2 error(Debian, Ubuntu)
> -------
> ./vanitygen: error while loading shared libraries: libcrypto.so.1.0.2: cannot open shared object file: No such file or directory
> 
> wget http://ftp.us.debian.org/debian/pool/main/g/glibc/libc6-udeb_2.24-9_amd64.udeb
> dpkg -i libc6-udeb_2.24-9_amd64.udeb
> wget http://ftp.us.debian.org/debian/pool/main/o/openssl1.0/libcrypto1.0.2-udeb_1.0.2k-1_amd64.udeb
> dpkg -i libcrypto1.0.2-udeb_1.0.2k-1_amd64.udeb
> rm libc6-udeb_2.24-9_amd64.udeb
> rm libcrypto1.0.2-udeb_1.0.2k-1_amd64.udeb
> -------
> END Fix libcrypto.so.1.0.2 error(Debian, Ubuntu)
> -------

Donation address if anyone feels generous: FgRoEST1y9bLyQWiRQ7ZnhHH9fNne1pCMW

PS: Are you compiling the Windows binary using mingw gcc or cygwin?  Or what are you using to compile the Windows binaries?  I noticed the Makefile.Win32 wasn't updated.  I'm using VS2012 x86 Native Tools on a Win10 VM to make sure others can succeed at compiling it:
> nmake /FMakefile.Win32 vanitygen.exe oclvanitygen.exe

Thanks for letting me help and accepting my PR's
-Corey Harding